### PR TITLE
WIP: Ability to select network interface for multicast address

### DIFF
--- a/knx/router.go
+++ b/knx/router.go
@@ -119,7 +119,7 @@ func (router *Router) serve() {
 
 // NewRouter creates a new Router that joins the given multicast group. You may pass a
 // zero-initialized value as parameter config, the default values will be set up.
-func NewRouter(multicastAddress string, config RouterConfig) (*Router, error) {
+func NewRouter(multicastAddress knxnet.MulticastAddress, config RouterConfig) (*Router, error) {
 	sock, err := knxnet.ListenRouter(multicastAddress)
 	if err != nil {
 		return nil, err
@@ -182,7 +182,7 @@ type GroupRouter struct {
 }
 
 // NewGroupRouter creates a new Router for group communication.
-func NewGroupRouter(multicastAddress string, config RouterConfig) (gr GroupRouter, err error) {
+func NewGroupRouter(multicastAddress knxnet.MulticastAddress, config RouterConfig) (gr GroupRouter, err error) {
 	gr.Router, err = NewRouter(multicastAddress, config)
 
 	if err == nil {


### PR DESCRIPTION
Hi Ole, 

I had a chance to play with your knx-go package. It actually helped me a lot with my weekend project. But I had to change a base code a bit to make it working for me. 

I'm using OpenVPN tunnel to communicate with KNXnet/IP gateway (RaspberryPI + knxd). When I tried to send a multicast UDP packet as in Readme example, packet went through en0 (eth0) interface but didn't reach KNX router. I had to change `net.ListenMulticastUDP` call to pass tunnel network interface (utun1 in my case) as a one to use for KNX telegrams. Only then my multicast messages reached the router. 

I didn't found any contribution guide, so I guess this repo is just your playground. 
Please tell me if you are interested in getting PRs for this repository. If so I would be happy to prepare a proper PR then.

This is how end user code may look like with this change:
```go
func main() {
	util.Logger = log.New(os.Stdout, "", log.LstdFlags)

	inf, err := net.InterfaceByName("utun1")
	if err != nil {
		log.Fatal("Interface not found")
	}

	addr, err := net.ResolveUDPAddr("udp4", "224.0.23.12:3671")
	if err != nil {
		log.Fatal("Failed to resolve router mutlticast address")
	}

	maddr := knxnet.MulticastAddress{
		Addr: addr,
		Iface: inf,
	}

	client, err := knx.NewGroupRouter(maddr, knx.DefaultRouterConfig)
	if err != nil {
		log.Fatal("Failed connection to knxserver", err)
	}

	defer client.Close()
}
```

Best Regards,
Alex