### PR TITLE
Add multicast interfaces to router config

### DIFF
--- a/knx/knxnet/socket.go
+++ b/knx/knxnet/socket.go
@@ -74,12 +74,19 @@ type RouterSocket struct {
 // ListenRouter creates a new Socket which can be used to exchange KNXnet/IP packets with
 // multiple endpoints.
 func ListenRouter(multicastAddress string) (*RouterSocket, error) {
+	return ListenRouterOnInterface(nil, multicastAddress)
+}
+
+// ListenRouterOnInterface creates a new Socket which can be used to exchange KNXnet/IP packets with
+// multiple endpoints. The interface is used to send or listen for KNXNet/IP packets. If the
+// interface is nil, the system-assigned multicast interface is used.
+func ListenRouterOnInterface(ifi *net.Interface, multicastAddress string) (*RouterSocket, error) {
 	addr, err := net.ResolveUDPAddr("udp4", multicastAddress)
 	if err != nil {
 		return nil, err
 	}
 
-	conn, err := net.ListenMulticastUDP("udp4", nil, addr)
+	conn, err := net.ListenMulticastUDP("udp4", ifi, addr)
 	if err != nil {
 		return nil, err
 	}

--- a/knx/router.go
+++ b/knx/router.go
@@ -6,6 +6,7 @@ package knx
 import (
 	"container/list"
 	"errors"
+	"net"
 	"sync"
 	"time"
 
@@ -19,6 +20,9 @@ type RouterConfig struct {
 	// Specify how many sent messages to retain. This is important for when a router indicates that
 	// it has lost some messages. If you do not expect to saturate the router, keep this low.
 	RetainCount uint
+	// Specifies the interface used to send and receive KNXNet/IP packets. If the interface
+	// is nil, the system-assigned multicast interface is used.
+	Interface *net.Interface
 }
 
 // DefaultRouterConfig is a good default configuration for a Router client.
@@ -120,7 +124,7 @@ func (router *Router) serve() {
 // NewRouter creates a new Router that joins the given multicast group. You may pass a
 // zero-initialized value as parameter config, the default values will be set up.
 func NewRouter(multicastAddress string, config RouterConfig) (*Router, error) {
-	sock, err := knxnet.ListenRouter(multicastAddress)
+	sock, err := knxnet.ListenRouterOnInterface(config.Interface, multicastAddress)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add multicast interfaces to router config. This allows to specify the exact interface to be used on a multi-interface system.