### PR TITLE
Add DPT 9.005 (Wind Speed)

### DIFF
--- a/knx/dpt/types.go
+++ b/knx/dpt/types.go
@@ -298,6 +298,45 @@ func (d DPT_9004) String() string {
 	return fmt.Sprintf("%.2f lux", float32(d))
 }
 
+// DPT_9005 represents DPT 9.005 / Wind Speed.
+type DPT_9005 float32
+
+func (d DPT_9005) Pack() []byte {
+    if d <= 0 {
+        return packF16(0)
+    } else if d >= 670760 {
+        return packF16(670760)
+    } else {
+        return packF16(float32(d))
+    }
+}
+
+func (d *DPT_9005) Unpack(data []byte) error {
+    var value float32
+    if err := unpackF16(data, &value); err != nil {
+        return err
+    }
+
+    // Check the value for valid range
+    if value < 0 {
+        return fmt.Errorf("Wind speed \"%.2f\" outside range [0, 670760]", value)
+    } else if value > 670760 {
+        return fmt.Errorf("Wind speed \"%.2f\" outside range [0, 670760]", value)
+    }
+
+    *d = DPT_9005(value)
+
+    return nil
+}
+
+func (d DPT_9005) Unit() string {
+    return "m/s"
+}
+
+func (d DPT_9005) String() string {
+    return fmt.Sprintf("%.2f m/s", float32(d))
+}
+
 // DPT_12001 represents DPT 12.001 / Unsigned counter.
 type DPT_12001 uint32
 

--- a/knx/dpt/types_test.go
+++ b/knx/dpt/types_test.go
@@ -232,6 +232,33 @@ func TestDPT_9004(t *testing.T) {
 	}
 }
 
+// Test DPT 9.005 (Wind Speed) with values within range
+func TestDPT_9005(t *testing.T) {
+	var buf []byte
+	var src, dst DPT_9005
+
+	for i := 1; i <= 10; i++ {
+		value := rand.Float32()
+
+		// Scale the random number to the given range
+		value *= 670760
+
+		// Calculate the quantization error we expect
+		Q := get_float_quantization_error(value, 0.01, 2047)
+
+		// Pack and unpack to test value
+		src = DPT_9005(value)
+		if abs(float32(src)-value) > epsilon {
+			t.Errorf("Assignment of value \"%v\" failed for source of type DPT_9005! Has value \"%s\".", value, src)
+		}
+		buf = src.Pack()
+		dst.Unpack(buf)
+		if abs(float32(dst)-value) > (Q + epsilon) {
+			t.Errorf("Value \"%s\" after pack/unpack above quantization noise! Original value was \"%v\", noise is \"%f\"", dst, value, Q)
+		}
+	}
+}
+
 // Test DPT 12.001 (Unsigned counter) with values within range
 func TestDPT_12001(t *testing.T) {
 	var buf []byte


### PR DESCRIPTION
This pull request adds support for the KNX datapoint type 9.005 which represents wind speeds. The type is pretty similar to 9.004 especially regarding the upper bounds.