### PR TITLE
Do not unpack if data is empty

### DIFF
--- a/knx/knxnet/proto.go
+++ b/knx/knxnet/proto.go
@@ -133,10 +133,6 @@ func Unpack(data []byte, srv *Service) (uint, error) {
 	var headerLen, version uint8
 	var srvID ServiceID
 	var totalLen uint16
-	
-	if len(data) == 0 {
-		return 0, nil
-	}
 
 	n, err := util.UnpackSome(data, &headerLen, &version, (*uint16)(&srvID), &totalLen)
 	if err != nil {

--- a/knx/knxnet/proto.go
+++ b/knx/knxnet/proto.go
@@ -133,6 +133,10 @@ func Unpack(data []byte, srv *Service) (uint, error) {
 	var headerLen, version uint8
 	var srvID ServiceID
 	var totalLen uint16
+	
+	if len(data) == 0 {
+		return 0, nil
+	}
 
 	n, err := util.UnpackSome(data, &headerLen, &version, (*uint16)(&srvID), &totalLen)
 	if err != nil {

--- a/knx/knxnet/socket.go
+++ b/knx/knxnet/socket.go
@@ -141,6 +141,11 @@ func serveUDPSocket(conn *net.UDPConn, addr *net.UDPAddr, inbound chan<- Service
 			return
 		}
 
+		// discard empty frames
+		if len == 0 {
+			continue
+		}
+
 		// Validate sender origin if necessary
 		if addr != nil && (!addr.IP.Equal(sender.IP) || addr.Port != sender.Port) {
 			util.Log(conn, "Origin validation failed: %v != %v", addr, sender)


### PR DESCRIPTION
Under normal operations I see a lot of log messages like this:
```*net.UDPConn[0xc000010098]: Error during Unpack: unexpected EOF```

It seems this is due to the Unpack function being called with and empty 'data'. This small changes causes the error condition to be ignored.