### PR TITLE
Fix DPT 5.003 producing NaNs during scaling

### DIFF
--- a/knx/dpt/types.go
+++ b/knx/dpt/types.go
@@ -178,7 +178,7 @@ func (d DPT_5003) Pack() []byte {
 	} else if d >= 360 {
 		return packU8(255)
 	} else {
-		return packU8(uint8(d * (255 / 360)))
+		return packU8(uint8(d * 255 / 360))
 	}
 }
 
@@ -188,7 +188,7 @@ func (d *DPT_5003) Unpack(data []byte) error {
 		return err
 	}
 
-	*d = DPT_5003(value) / (255 / 360)
+	*d = DPT_5003(value) * 360 / 255
 
 	return nil
 }

--- a/knx/dpt/types_test.go
+++ b/knx/dpt/types_test.go
@@ -144,6 +144,9 @@ func TestDPT_5001(t *testing.T) {
 		}
 		buf = src.Pack()
 		dst.Unpack(buf)
+		if math.IsNaN(float64(dst)) {
+			t.Errorf("Value \"%s\" is not a valid number! Original value was \"%v\".", dst, value)
+		}
 		if abs(float32(dst)-value) > (Q + epsilon) {
 			t.Errorf("Value \"%s\" after pack/unpack above quantization noise! Original value was \"%v\", noise is \"%f\"", dst, value, Q)
 		}
@@ -171,6 +174,9 @@ func TestDPT_5003(t *testing.T) {
 		}
 		buf = src.Pack()
 		dst.Unpack(buf)
+		if math.IsNaN(float64(dst)) {
+			t.Errorf("Value \"%s\" is not a valid number! Original value was \"%v\".", dst, value)
+		}
 		if abs(float32(dst)-value) > (Q + epsilon) {
 			t.Errorf("Value \"%s\" after pack/unpack above quantization noise! Original value was \"%v\", noise is \"%f\"", dst, value, Q)
 		}
@@ -199,6 +205,9 @@ func TestDPT_9001(t *testing.T) {
 		}
 		buf = src.Pack()
 		dst.Unpack(buf)
+		if math.IsNaN(float64(dst)) {
+			t.Errorf("Value \"%s\" is not a valid number! Original value was \"%v\".", dst, value)
+		}
 		if abs(float32(dst)-value) > (Q + epsilon) {
 			t.Errorf("Value \"%s\" after pack/unpack above quantization noise! Original value was \"%v\", noise is \"%f\"", dst, value, Q)
 		}
@@ -226,6 +235,9 @@ func TestDPT_9004(t *testing.T) {
 		}
 		buf = src.Pack()
 		dst.Unpack(buf)
+		if math.IsNaN(float64(dst)) {
+			t.Errorf("Value \"%s\" is not a valid number! Original value was \"%v\".", dst, value)
+		}
 		if abs(float32(dst)-value) > (Q + epsilon) {
 			t.Errorf("Value \"%s\" after pack/unpack above quantization noise! Original value was \"%v\", noise is \"%f\"", dst, value, Q)
 		}
@@ -253,6 +265,9 @@ func TestDPT_9005(t *testing.T) {
 		}
 		buf = src.Pack()
 		dst.Unpack(buf)
+		if math.IsNaN(float64(dst)) {
+			t.Errorf("Value \"%s\" is not a valid number! Original value was \"%v\".", dst, value)
+		}
 		if abs(float32(dst)-value) > (Q + epsilon) {
 			t.Errorf("Value \"%s\" after pack/unpack above quantization noise! Original value was \"%v\", noise is \"%f\"", dst, value, Q)
 		}
@@ -280,6 +295,9 @@ func TestDPT_9007(t *testing.T) {
 		}
 		buf = src.Pack()
 		dst.Unpack(buf)
+		if math.IsNaN(float64(dst)) {
+			t.Errorf("Value \"%s\" is not a valid number! Original value was \"%v\".", dst, value)
+		}
 		if abs(float32(dst)-value) > (Q + epsilon) {
 			t.Errorf("Value \"%s\" after pack/unpack above quantization noise! Original value was \"%v\", noise is \"%f\"", dst, value, Q)
 		}


### PR DESCRIPTION
DPT 5.003 produces NaNs when scaling the input values during pack/unpack. Furthermore, this pull-request improves the unit-test to also detect NaN values for float types.