### PR TITLE
DPT 251.600 RGBW added

### DIFF
--- a/knx/dpt/formats.go
+++ b/knx/dpt/formats.go
@@ -30,6 +30,40 @@ func unpackB1(data []byte, b *bool) error {
 	return nil
 }
 
+func packB4(b0 bool, b1 bool, b2 bool, b3 bool) byte {
+	var b int
+	b = 0
+	if b3 {
+		b += 1 << 0
+	}
+	if b2 {
+		b += 1 << 1
+	}
+	if b1 {
+		b += 1 << 2
+	}
+	if b0 {
+		b += 1 << 3
+	}
+
+	return byte(b)
+
+}
+
+func unpackB4(data byte, b0 *bool, b1 *bool, b2 *bool, b3 *bool) error {
+
+	if uint8(data) > 15 {
+		return ErrInvalidLength
+	}
+
+	*b3 = ((data >> 0) & 1) != 0
+	*b2 = ((data >> 1) & 1) != 0
+	*b1 = ((data >> 2) & 1) != 0
+	*b0 = ((data >> 3) & 1) != 0
+
+	return nil
+}
+
 func packF16(f float32) []byte {
 	buffer := []byte{0, 0, 0}
 

--- a/knx/dpt/formats.go
+++ b/knx/dpt/formats.go
@@ -9,8 +9,12 @@ import (
 	"math"
 )
 
-// ErrInvalidLength is returned when the application data has unexpected length.
-var ErrInvalidLength = errors.New("given application data has invalid length")
+var (
+	// ErrInvalidLength is returned when the application data has unexpected length.
+	ErrInvalidLength = errors.New("given application data has invalid length")
+	// ErrBadReservedBits is returned when reserved bits are populated. E.g. if bit number 5 of a r4B4 field is populated
+	ErrBadReservedBits = errors.New("reserved bits in the input data have been populated")
+)
 
 func packB1(b bool) []byte {
 	if b {
@@ -31,8 +35,7 @@ func unpackB1(data []byte, b *bool) error {
 }
 
 func packB4(bs [4]bool) byte {
-	var b byte
-	b = 0
+	var b byte = 0
 	if bs[0] {
 		b |= 1 << 0
 	}
@@ -47,13 +50,12 @@ func packB4(bs [4]bool) byte {
 	}
 
 	return byte(b)
-
 }
 
 func unpackB4(data byte, b0 *bool, b1 *bool, b2 *bool, b3 *bool) error {
 
 	if uint8(data) > 15 {
-		return ErrInvalidLength
+		return ErrBadReservedBits
 	}
 
 	*b0 = ((data >> 0) & 1) != 0

--- a/knx/dpt/formats.go
+++ b/knx/dpt/formats.go
@@ -30,20 +30,20 @@ func unpackB1(data []byte, b *bool) error {
 	return nil
 }
 
-func packB4(b0 bool, b1 bool, b2 bool, b3 bool) byte {
-	var b int
+func packB4(bs [4]bool) byte {
+	var b byte
 	b = 0
-	if b3 {
-		b += 1 << 0
+	if bs[0] {
+		b |= 1 << 0
 	}
-	if b2 {
-		b += 1 << 1
+	if bs[1] {
+		b |= 1 << 1
 	}
-	if b1 {
-		b += 1 << 2
+	if bs[2] {
+		b |= 1 << 2
 	}
-	if b0 {
-		b += 1 << 3
+	if bs[3] {
+		b |= 1 << 3
 	}
 
 	return byte(b)
@@ -56,10 +56,10 @@ func unpackB4(data byte, b0 *bool, b1 *bool, b2 *bool, b3 *bool) error {
 		return ErrInvalidLength
 	}
 
-	*b3 = ((data >> 0) & 1) != 0
-	*b2 = ((data >> 1) & 1) != 0
-	*b1 = ((data >> 2) & 1) != 0
-	*b0 = ((data >> 3) & 1) != 0
+	*b0 = ((data >> 0) & 1) != 0
+	*b1 = ((data >> 1) & 1) != 0
+	*b2 = ((data >> 2) & 1) != 0
+	*b3 = ((data >> 3) & 1) != 0
 
 	return nil
 }

--- a/knx/dpt/types_251.go
+++ b/knx/dpt/types_251.go
@@ -18,7 +18,7 @@ type DPT_251600 struct {
 
 func (d DPT_251600) Pack() []byte {
 
-	validBits := packB4(d.RedValid, d.GreenValid, d.BlueValid, d.WhiteValid)
+	validBits := packB4([4]bool{d.WhiteValid, d.BlueValid, d.GreenValid, d.RedValid})
 
 	return []byte{0, d.Red, d.Green, d.Blue, d.White, uint8(0), validBits}
 }
@@ -31,7 +31,7 @@ func (d *DPT_251600) Unpack(data []byte) error {
 
 	var redValid, greenValid, blueValid, whiteValid bool
 
-	err := unpackB4(data[6], &redValid, &greenValid, &blueValid, &whiteValid)
+	err := unpackB4(data[6], &whiteValid, &blueValid, &greenValid, &redValid)
 
 	if err != nil {
 		return ErrInvalidLength

--- a/knx/dpt/types_251.go
+++ b/knx/dpt/types_251.go
@@ -1,0 +1,59 @@
+package dpt
+
+import (
+	"fmt"
+)
+
+// DPT_251600 represents DPT 251.600 / Colour RGBW - RGBW value 4x(0..100%) / U8 U8 U8 U8 r8 r4B4
+type DPT_251600 struct {
+	Red        uint8
+	Green      uint8
+	Blue       uint8
+	White      uint8
+	RedValid   bool
+	GreenValid bool
+	BlueValid  bool
+	WhiteValid bool
+}
+
+func (d DPT_251600) Pack() []byte {
+
+	validBits := packB4(d.RedValid, d.GreenValid, d.BlueValid, d.WhiteValid)
+
+	return []byte{0, d.Red, d.Green, d.Blue, d.White, uint8(0), validBits}
+}
+
+func (d *DPT_251600) Unpack(data []byte) error {
+
+	if len(data) != 7 {
+		return ErrInvalidLength
+	}
+
+	var redValid, greenValid, blueValid, whiteValid bool
+
+	err := unpackB4(data[6], &redValid, &greenValid, &blueValid, &whiteValid)
+
+	if err != nil {
+		return ErrInvalidLength
+	}
+
+	*d = DPT_251600{
+		Red:        uint8(data[1]),
+		Green:      uint8(data[2]),
+		Blue:       uint8(data[3]),
+		White:      uint8(data[4]),
+		RedValid:   redValid,
+		GreenValid: greenValid,
+		BlueValid:  blueValid,
+		WhiteValid: whiteValid,
+	}
+	return nil
+}
+
+func (d DPT_251600) Unit() string {
+	return ""
+}
+
+func (d DPT_251600) String() string {
+	return fmt.Sprintf("Red: %d Green: %d Blue: %d White: %d RedValid: %t, GreenValid: %t, BlueValid: %t, WhiteValid: %t", d.Red, d.Green, d.Blue, d.White, d.RedValid, d.GreenValid, d.BlueValid, d.WhiteValid)
+}

--- a/knx/dpt/types_251_test.go
+++ b/knx/dpt/types_251_test.go
@@ -1,0 +1,32 @@
+package dpt
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestDPT_251600(t *testing.T) {
+	var buf []byte
+	var dst DPT_251600
+	var sources []DPT_251600
+
+	sources = append(sources, DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: true, BlueValid: true, WhiteValid: true})
+	sources = append(sources, DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: false, GreenValid: false, BlueValid: false, WhiteValid: false})
+
+	sources = append(sources, DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: false, GreenValid: true, BlueValid: true, WhiteValid: true})
+	sources = append(sources, DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: false, BlueValid: true, WhiteValid: true})
+	sources = append(sources, DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: true, BlueValid: false, WhiteValid: true})
+	sources = append(sources, DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: true, BlueValid: true, WhiteValid: false})
+
+	for _, src := range sources {
+		buf = src.Pack()
+		_ = dst.Unpack(buf)
+
+		if !reflect.DeepEqual(src, dst) {
+			fmt.Printf("%+v\n", src)
+			fmt.Printf("%+v\n", dst)
+			t.Errorf("Value \"%s\" after pack/unpack for DPT_251600 differs. Original value was \"%v\"!", dst, src)
+		}
+	}
+}

--- a/knx/dpt/types_251_test.go
+++ b/knx/dpt/types_251_test.go
@@ -10,13 +10,13 @@ func TestDPT_251600(t *testing.T) {
 	var buf []byte
 	var dst DPT_251600
 	sources := []DPT_251600{
-		DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: true, BlueValid: true, WhiteValid: true},
-		DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: false, GreenValid: false, BlueValid: false, WhiteValid: false},
+		{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: true, BlueValid: true, WhiteValid: true},
+		{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: false, GreenValid: false, BlueValid: false, WhiteValid: false},
 
-		DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: false, GreenValid: true, BlueValid: true, WhiteValid: true},
-		DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: false, BlueValid: true, WhiteValid: true},
-		DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: true, BlueValid: false, WhiteValid: true},
-		DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: true, BlueValid: true, WhiteValid: false},
+		{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: false, GreenValid: true, BlueValid: true, WhiteValid: true},
+		{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: false, BlueValid: true, WhiteValid: true},
+		{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: true, BlueValid: false, WhiteValid: true},
+		{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: true, BlueValid: true, WhiteValid: false},
 	}
 
 	for _, src := range sources {

--- a/knx/dpt/types_251_test.go
+++ b/knx/dpt/types_251_test.go
@@ -9,15 +9,15 @@ import (
 func TestDPT_251600(t *testing.T) {
 	var buf []byte
 	var dst DPT_251600
-	var sources []DPT_251600
+	sources := []DPT_251600{
+		DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: true, BlueValid: true, WhiteValid: true},
+		DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: false, GreenValid: false, BlueValid: false, WhiteValid: false},
 
-	sources = append(sources, DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: true, BlueValid: true, WhiteValid: true})
-	sources = append(sources, DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: false, GreenValid: false, BlueValid: false, WhiteValid: false})
-
-	sources = append(sources, DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: false, GreenValid: true, BlueValid: true, WhiteValid: true})
-	sources = append(sources, DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: false, BlueValid: true, WhiteValid: true})
-	sources = append(sources, DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: true, BlueValid: false, WhiteValid: true})
-	sources = append(sources, DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: true, BlueValid: true, WhiteValid: false})
+		DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: false, GreenValid: true, BlueValid: true, WhiteValid: true},
+		DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: false, BlueValid: true, WhiteValid: true},
+		DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: true, BlueValid: false, WhiteValid: true},
+		DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: true, BlueValid: true, WhiteValid: false},
+	}
 
 	for _, src := range sources {
 		buf = src.Pack()

--- a/knx/dpt/types_registry.go
+++ b/knx/dpt/types_registry.go
@@ -150,6 +150,8 @@ var (
 		new(DPT_17001),
 		// 18.xxx
 		new(DPT_18001),
+		// 251.xxx
+		new(DPT_251600),
 	}
 	once     sync.Once
 	registry map[string]reflect.Type


### PR DESCRIPTION
This pull request adds DPT 251.600. As it is a combined data type I thought the best solution is to create a struct for the 4 color `unit8` and 4 color valid bits.

What do you think?

```go
	orange := dpt.DPT_251600{Red: 255, Green: 96, Blue: 0, White: 18, RedValid: true, GreenValid: true, BlueValid: true, WhiteValid: true}

	err = client.Send(knx.GroupEvent{
		Command:     knx.GroupWrite,
		Destination: cemi.NewGroupAddr3(3, 0, 0),
		Data:        orange.Pack(),
	})
	if err != nil {
		log.Fatal(err)
	}
```