### PR TITLE
Added MulticastLoopback + fixed WaitTime

### DIFF
--- a/cmd/knxbridge/main.go
+++ b/cmd/knxbridge/main.go
@@ -98,7 +98,7 @@ func newBridge(gatewayAddr, otherAddr string) (*bridge, error) {
 	}
 
 	if addr.IP.IsMulticast() {
-		// Instantiate routing facilities.
+		// Instantiate routing facilities. MulticastLoopback is disabled by default.
 		router, err := knx.NewRouter(otherAddr, knx.DefaultRouterConfig)
 		if err != nil {
 			tunnel.Close()

--- a/knx/discover.go
+++ b/knx/discover.go
@@ -9,15 +9,15 @@ import (
 	"github.com/vapourismo/knx-go/knx/knxnet"
 )
 
-// Discover all KNXnet/IP Server
+// Discover all KNXnet/IP servers.
 func Discover(multicastDiscoveryAddress string, searchTimeout time.Duration) ([]*knxnet.SearchRes, error) {
 	return DiscoverOnInterface(nil, multicastDiscoveryAddress, searchTimeout)
 }
 
-// DiscoverOnInterface discovers all KNXnet/IP Server on a specific interface. If the
+// DiscoverOnInterface discovers all KNXnet/IP servers on a specific interface. If the
 // interface is nil, the system-assigned multicast interface is used.
 func DiscoverOnInterface(ifi *net.Interface, multicastDiscoveryAddress string, searchTimeout time.Duration) ([]*knxnet.SearchRes, error) {
-	socket, err := knxnet.ListenRouterOnInterface(ifi, multicastDiscoveryAddress)
+	socket, err := knxnet.ListenRouterOnInterface(ifi, multicastDiscoveryAddress, false)
 	if err != nil {
 		return nil, err
 	}

--- a/knx/knxnet/router.go
+++ b/knx/knxnet/router.go
@@ -94,7 +94,7 @@ type RoutingBusy struct {
 	// Device status
 	Status DeviceState
 
-	// Time to wait (received in milliseconds)
+	// Time to wait
 	WaitTime time.Duration
 
 	// If set to 0x00, must pause sending

--- a/knx/knxnet/router.go
+++ b/knx/knxnet/router.go
@@ -94,10 +94,10 @@ type RoutingBusy struct {
 	// Device status
 	Status DeviceState
 
-	// Time to wait
+	// Time to wait (received in milliseconds)
 	WaitTime time.Duration
 
-	// ?
+	// If set to 0x00, must pause sending
 	Control uint16
 }
 

--- a/knx/knxnet/socket.go
+++ b/knx/knxnet/socket.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/vapourismo/knx-go/knx/util"
+	"golang.org/x/net/ipv4"
 )
 
 // A Socket is a socket, duh.
@@ -81,21 +82,51 @@ type RouterSocket struct {
 // ListenRouter creates a new Socket which can be used to exchange KNXnet/IP packets with
 // multiple endpoints.
 func ListenRouter(multicastAddress string) (*RouterSocket, error) {
-	return ListenRouterOnInterface(nil, multicastAddress)
+	return ListenRouterOnInterface(nil, multicastAddress, false)
 }
 
 // ListenRouterOnInterface creates a new Socket which can be used to exchange KNXnet/IP packets with
-// multiple endpoints. The interface is used to send or listen for KNXNet/IP packets. If the
+// multiple endpoints. The interface is used to send or listen for KNXnet/IP packets. If the
 // interface is nil, the system-assigned multicast interface is used.
-func ListenRouterOnInterface(ifi *net.Interface, multicastAddress string) (*RouterSocket, error) {
+func ListenRouterOnInterface(ifi *net.Interface, multicastAddress string, multicastLoopbackEnabled bool) (*RouterSocket, error) {
 	addr, err := net.ResolveUDPAddr("udp4", multicastAddress)
 	if err != nil {
 		return nil, err
 	}
 
-	conn, err := net.ListenMulticastUDP("udp4", ifi, addr)
+	conn, err := net.ListenUDP("udp4", addr)
 	if err != nil {
 		return nil, err
+	}
+	pc := ipv4.NewPacketConn(conn)
+
+	if err := pc.JoinGroup(ifi, addr); err != nil {
+		return nil, err
+	}
+
+	// Setup interface with Multicast Loopback enabled if desired.
+	// Set it verbosely in case logging is enabled.
+	if loopOn, err := pc.MulticastLoopback(); err == nil {
+		util.Log(conn, "MulticastLoopback status: %t", loopOn)
+		if loopOn {
+			if !multicastLoopbackEnabled {
+				if err := pc.SetMulticastLoopback(false); err != nil {
+					util.Log(conn, "SetMulticastLoopback error: %v", err)
+				} else {
+					util.Log(conn, "MulticastLoopback disabled")
+				}
+			}
+		} else {
+			if multicastLoopbackEnabled {
+				if err := pc.SetMulticastLoopback(true); err != nil {
+					util.Log(conn, "SetMulticastLoopback error: %v", err)
+				} else {
+					util.Log(conn, "MulticastLoopback enabled")
+				}
+			}
+		}
+	} else {
+		util.Log(conn, "Cannot query MulticastLoopback: %v", err)
 	}
 
 	conn.SetDeadline(time.Time{})
@@ -106,7 +137,7 @@ func ListenRouterOnInterface(ifi *net.Interface, multicastAddress string) (*Rout
 	return &RouterSocket{conn, addr, inbound}, nil
 }
 
-// Addr returns the multicast destination address
+// Addr returns the multicast destination address.
 func (sock *RouterSocket) Addr() *net.UDPAddr {
 	return sock.addr
 }
@@ -154,7 +185,7 @@ func serveUDPSocket(conn *net.UDPConn, addr *net.UDPAddr, inbound chan<- Service
 			return
 		}
 
-		// discard empty frames
+		// Discard empty frames
 		if len == 0 {
 			continue
 		}

--- a/knx/knxnet/socket.go
+++ b/knx/knxnet/socket.go
@@ -109,13 +109,11 @@ func ListenRouterOnInterface(ifi *net.Interface, multicastAddress string, multic
 		util.Log(conn, "MulticastLoopback status: %v", loopOn)
 	}
 	// Setup interface with Multicast Loopback enabled if desired.
-	/*
-		if err := pc.SetMulticastLoopback(multicastLoopbackEnabled); err != nil {
-			util.Log(conn, "SetMulticastLoopback error: %v", err)
-		} else {
-			util.Log(conn, "MulticastLoopbackEnabled: %t", multicastLoopbackEnabled)
-		}
-	*/
+	if err := pc.SetMulticastLoopback(multicastLoopbackEnabled); err != nil {
+		util.Log(conn, "SetMulticastLoopback error: %v", err)
+	} else {
+		util.Log(conn, "MulticastLoopbackEnabled: %t", multicastLoopbackEnabled)
+	}
 
 	conn.SetDeadline(time.Time{})
 

--- a/knx/knxnet/socket.go
+++ b/knx/knxnet/socket.go
@@ -104,30 +104,18 @@ func ListenRouterOnInterface(ifi *net.Interface, multicastAddress string, multic
 		return nil, err
 	}
 
-	// Setup interface with Multicast Loopback enabled if desired.
-	// Set it verbosely in case logging is enabled.
+	// Just for logging purposes.
 	if loopOn, err := pc.MulticastLoopback(); err == nil {
-		util.Log(conn, "MulticastLoopback status: %t", loopOn)
-		if loopOn {
-			if !multicastLoopbackEnabled {
-				if err := pc.SetMulticastLoopback(false); err != nil {
-					util.Log(conn, "SetMulticastLoopback error: %v", err)
-				} else {
-					util.Log(conn, "MulticastLoopback disabled")
-				}
-			}
-		} else {
-			if multicastLoopbackEnabled {
-				if err := pc.SetMulticastLoopback(true); err != nil {
-					util.Log(conn, "SetMulticastLoopback error: %v", err)
-				} else {
-					util.Log(conn, "MulticastLoopback enabled")
-				}
-			}
-		}
-	} else {
-		util.Log(conn, "Cannot query MulticastLoopback: %v", err)
+		util.Log(conn, "MulticastLoopback status: %v", loopOn)
 	}
+	// Setup interface with Multicast Loopback enabled if desired.
+	/*
+		if err := pc.SetMulticastLoopback(multicastLoopbackEnabled); err != nil {
+			util.Log(conn, "SetMulticastLoopback error: %v", err)
+		} else {
+			util.Log(conn, "MulticastLoopbackEnabled: %t", multicastLoopbackEnabled)
+		}
+	*/
 
 	conn.SetDeadline(time.Time{})
 

--- a/knx/router.go
+++ b/knx/router.go
@@ -134,11 +134,7 @@ func (router *Router) serve() {
 
 // NewRouter creates a new Router that joins the given multicast group. You may pass a
 // zero-initialized value as parameter config, the default values will be set up.
-// If multicastAddress is an empty string, KNX default, "224.0.23.12:3671", will be used.
 func NewRouter(multicastAddress string, config RouterConfig) (*Router, error) {
-	if multicastAddress == "" {
-		multicastAddress = "224.0.23.12:3671"
-	}
 	config = checkRouterConfig(config)
 
 	sock, err := knxnet.ListenRouterOnInterface(config.Interface, multicastAddress, config.MulticastLoopbackEnabled)

--- a/knx/router.go
+++ b/knx/router.go
@@ -6,6 +6,7 @@ package knx
 import (
 	"container/list"
 	"errors"
+	"math/rand"
 	"net"
 	"sync"
 	"time"
@@ -20,14 +21,17 @@ type RouterConfig struct {
 	// Specify how many sent messages to retain. This is important for when a router indicates that
 	// it has lost some messages. If you do not expect to saturate the router, keep this low.
 	RetainCount uint
-	// Specifies the interface used to send and receive KNXNet/IP packets. If the interface
+	// Specifies the interface used to send and receive KNXnet/IP packets. If the interface
 	// is nil, the system-assigned multicast interface is used.
 	Interface *net.Interface
+	// Specifies if Multicast Loopback should be enabled.
+	MulticastLoopbackEnabled bool
 }
 
 // DefaultRouterConfig is a good default configuration for a Router client.
 var DefaultRouterConfig = RouterConfig{
-	RetainCount: 32,
+	RetainCount:              32,
+	MulticastLoopbackEnabled: false,
 }
 
 // checkRouterConfig validates the given RouterConfig.
@@ -104,15 +108,22 @@ func (router *Router) serve() {
 	for msg := range router.sock.Inbound() {
 		switch msg := msg.(type) {
 		case *knxnet.RoutingInd:
-			// Try to push it to the client without blocking this goroutine to long.
+			// Try to push it to the client without blocking this goroutine too long.
 			router.pushInbound(msg.Payload)
 
 		case *knxnet.RoutingBusy:
+			var trandom time.Duration
+			// If Control is 0, we should add a specified random amount of time
+			// to the WaitTime. Otherwise, it is not specified, we just wait WaitTime.
+			if msg.Control == 0 {
+				trandom = time.Duration(rand.Float64()*50) * time.Millisecond
+			}
+
 			// Inhibit sending for the given time.
 			router.sendMu.Lock()
-			time.AfterFunc(msg.WaitTime, router.sendMu.Unlock)
 
-			// TODO: Slow down pace after busy indication.
+			// TODO: Add timer to Router in case of receiving multiple RoutingBusy.
+			time.AfterFunc(msg.WaitTime+trandom, router.sendMu.Unlock)
 
 		case *knxnet.RoutingLost:
 			// Resend the last msg.Count messages.
@@ -123,15 +134,21 @@ func (router *Router) serve() {
 
 // NewRouter creates a new Router that joins the given multicast group. You may pass a
 // zero-initialized value as parameter config, the default values will be set up.
+// If multicastAddress is an empty string, KNX default, "224.0.23.12:3671", will be used.
 func NewRouter(multicastAddress string, config RouterConfig) (*Router, error) {
-	sock, err := knxnet.ListenRouterOnInterface(config.Interface, multicastAddress)
+	if multicastAddress == "" {
+		multicastAddress = "224.0.23.12:3671"
+	}
+	config = checkRouterConfig(config)
+
+	sock, err := knxnet.ListenRouterOnInterface(config.Interface, multicastAddress, config.MulticastLoopbackEnabled)
 	if err != nil {
 		return nil, err
 	}
 
 	r := &Router{
 		sock:     sock,
-		config:   checkRouterConfig(config),
+		config:   config,
 		inbound:  make(chan cemi.Message),
 		retainer: list.New(),
 	}
@@ -144,12 +161,17 @@ func NewRouter(multicastAddress string, config RouterConfig) (*Router, error) {
 // Send transmits a packet.
 func (router *Router) Send(data cemi.Message) error {
 	if data == nil {
-		return errors.New("Nil-pointers are not sendable")
+		return errors.New("nil-pointers are not sendable")
 	}
 
 	// We lock this before doing any sending so the server goroutine can adjust the flow control.
 	router.sendMu.Lock()
 	defer router.sendMu.Unlock()
+
+	// According to the specification, we may choose to always pause for 20 ms
+	// after transmitting, bu we should always pause for at least 5 ms on a multicast address.
+	// Use the safer variant, pause for 20 ms.
+	time.Sleep(20 * time.Millisecond)
 
 	err := router.sock.Send(&knxnet.RoutingInd{Payload: data})
 


### PR DESCRIPTION
The purpose of this PR is twofold:

1. Added MulticastLoopback to enable a sender and a receiver to co-exist on the same machine. For test purposes I wanted to have a sender and a listener on the same machine. Multicast loopback is disabled when using `net.ListenMulticastUDP("udp4", ifi, addr)`, therefore we use `net.ListenUDP("udp4", addr)` and join the multicast group. A new option which is false in the `DefaultRouterConfig `has been added. In addition, when address is empty, the default KNX address is used.
2. Fixed somewhat the send Timer (according to spec, a sender must wait for at least 5 ms between telegram sends or to avoid sending too many telegrams, wait for 20 ms to ensure that max 50 datagrams are sent per second). I choose to wait for 20 ms (should this be configurable?). On receiving ROUTING_BUSY, the listener shall wait for TIME_WAIT + a random time [0, 1]*50ms when Control is 0x00, otherwise not specified, in that case set random time = 0.

Plus a few dots and capitalizations (error strings should not be capitalized (ST1005) that's what go-staticcheck tells me).

Thank you.