### PR TITLE
Add Datapoint interface

### DIFF
--- a/knx/dpt/types.go
+++ b/knx/dpt/types.go
@@ -3,6 +3,8 @@
 
 package dpt
 
+import "fmt"
+
 // A DatapointValue is a value of a datapoint.
 type DatapointValue interface {
 	// Pack the datapoint to a byte array.
@@ -16,4 +18,7 @@ type DatapointValue interface {
 type DatapointMeta interface {
 	// Unit returns the unit of this datapoint type or empty string if it doesn't have a unit.
 	Unit() string
+
+	// fmt.Stringer provides a string representation of the datapoint.
+	fmt.Stringer
 }

--- a/knx/dpt/types.go
+++ b/knx/dpt/types.go
@@ -22,3 +22,9 @@ type DatapointMeta interface {
 	// fmt.Stringer provides a string representation of the datapoint.
 	fmt.Stringer
 }
+
+// Datapoint represents a datapoint with both its value and metadata.
+type Datapoint interface {
+	DatapointValue
+	DatapointMeta
+}

--- a/knx/dpt/types_registry.go
+++ b/knx/dpt/types_registry.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	types = [...]DatapointValue{
+	types = [...]Datapoint{
 		// 1.xxx
 		new(DPT_1001),
 		new(DPT_1002),
@@ -248,14 +248,14 @@ func ListSupportedTypes() []string {
 }
 
 // Produce creates a new instance of the given datapoint-type name e.g. "1.001".
-func Produce(name string) (d DatapointValue, ok bool) {
+func Produce(name string) (d Datapoint, ok bool) {
 	// Setup the registry
 	setup()
 
 	// Lookup the given type and create a new instance of that type
 	x, ok := registry[name]
 	if ok {
-		d = reflect.New(x).Interface().(DatapointValue)
+		d = reflect.New(x).Interface().(Datapoint)
 	}
 	return d, ok
 }


### PR DESCRIPTION
First off, thank you for the hard work you put into this library – it works very very well in my KNX-HomeKit bridge project (releasing as open source as well soon).

In that project I needed a way to create and store concrete values of datapoint types. The problem is that `Produce` only returns a `DatapointValue` so type assertions are necessary when trying to use `Unit()` (part of the `DatapointMeta` interface) or `String()` (from `fmt.Stringer`).

Would you consider this change of adding a combined interface and returning that from `Produce()`?

```go
type Datapoint interface {
	DatapointValue
	DatapointMeta
	fmt.Stringer
}
```

This change does not require any other changes besides the 3 I made in the type registry and the test suite is still green without any changes.

Thank you for considering it – in case you do accept the change I'd update the commit message description to explain the reasoning before the merge.