### PR TITLE
Re-added 20.105 (HVACContrMode): it went missing in rewrite of registry

### DIFF
--- a/knx/dpt/types_20_test.go
+++ b/knx/dpt/types_20_test.go
@@ -23,9 +23,10 @@ func TestDPT_20105(t *testing.T) {
 	knxValue := []byte{0, 9}
 	dptValue := DPT_20105(9)
 
-	var tmpDPT DPT_20105
+	tmpDPT, ok := Produce("20.105")
+	assert.True(t, ok)
 	assert.NoError(t, tmpDPT.Unpack(knxValue))
-	assert.Equal(t, dptValue, tmpDPT)
+	assert.Equal(t, &dptValue, tmpDPT)
 
 	assert.Equal(t, knxValue, dptValue.Pack())
 

--- a/knx/dpt/types_registry.go
+++ b/knx/dpt/types_registry.go
@@ -196,6 +196,7 @@ var dptTypes = map[string]Datapoint{
 
 	// 20.xxx
 	"20.102": new(DPT_20102),
+	"20.105": new(DPT_20105),
 
 	// 28.xxx
 	"28.001": new(DPT_28001),


### PR DESCRIPTION
Commit 922a0d by mobilarte <martin@maxsyma.com> on Feb 17, 2024 changed the DPT types registry and migrated the list of all the DPT types to a map, but in the process it did not migrate type "20.105".  I am doing so, and adding a test to check it (which could also be added to all the other types).