### PR TITLE
Add support for dpt 8.xxx (attempt 2)

### DIFF
--- a/knx/dpt/formats.go
+++ b/knx/dpt/formats.go
@@ -208,6 +208,63 @@ func unpackV8(data []byte, i *int8) error {
 	return nil
 }
 
+func packV16(i int16) []byte {
+	b := make([]byte, 3)
+
+	b[0] = 0
+	b[1] = byte((i >> 8) & 0xff)
+	b[2] = byte(i & 0xff)
+
+	return b
+}
+
+func unpackV16(data []byte, i *int16) error {
+	if len(data) != 3 {
+		return ErrInvalidLength
+	}
+
+	*i = int16(data[1])<<8 | int16(data[2])
+
+	return nil
+}
+
+func packV32AsV16(i int32, resolution int32) []byte {
+	return packV16(int16(i / resolution))
+}
+
+func unpackV16AsV32(data []byte, i *int32, resolution int32) error {
+	if len(data) != 3 {
+		return ErrInvalidLength
+	}
+	var i16 int16
+	err := unpackV16(data, &i16)
+	if err != nil {
+		return err
+	}
+
+	*i = int32(i16) * resolution
+	return nil
+}
+
+func packFloat32AsV16(f float32, resolution float32) []byte {
+	return packV16(int16(math.Round(float64(f / resolution))))
+}
+
+func unpackV16AsFloat32(data []byte, f *float32, resolution float32) error {
+	if len(data) != 3 {
+		return ErrInvalidLength
+	}
+
+	var i int16
+	if err := unpackV16(data, &i); err != nil {
+		return err
+	}
+
+	*f = float32(i) * resolution
+
+	return nil
+}
+
 func packV32(i int32) []byte {
 	b := make([]byte, 5)
 

--- a/knx/dpt/formats.go
+++ b/knx/dpt/formats.go
@@ -228,43 +228,6 @@ func unpackV16(data []byte, i *int16) error {
 	return nil
 }
 
-func packV32AsV16(i int32, resolution int32) []byte {
-	return packV16(int16(i / resolution))
-}
-
-func unpackV16AsV32(data []byte, i *int32, resolution int32) error {
-	if len(data) != 3 {
-		return ErrInvalidLength
-	}
-	var i16 int16
-	err := unpackV16(data, &i16)
-	if err != nil {
-		return err
-	}
-
-	*i = int32(i16) * resolution
-	return nil
-}
-
-func packFloat32AsV16(f float32, resolution float32) []byte {
-	return packV16(int16(math.Round(float64(f / resolution))))
-}
-
-func unpackV16AsFloat32(data []byte, f *float32, resolution float32) error {
-	if len(data) != 3 {
-		return ErrInvalidLength
-	}
-
-	var i int16
-	if err := unpackV16(data, &i); err != nil {
-		return err
-	}
-
-	*f = float32(i) * resolution
-
-	return nil
-}
-
 func packV32(i int32) []byte {
 	b := make([]byte, 5)
 

--- a/knx/dpt/types_8.go
+++ b/knx/dpt/types_8.go
@@ -5,6 +5,7 @@ package dpt
 
 import (
 	"fmt"
+	"math"
 )
 
 // DPT_8001 represents DPT 8.001 / Counter.
@@ -49,11 +50,16 @@ func (d DPT_8002) String() string {
 type DPT_8003 int32
 
 func (d DPT_8003) Pack() []byte {
-	return packV32AsV16(int32(d), 10)
+	return packV16(int16(int32(d) / 10))
 }
 
 func (d *DPT_8003) Unpack(data []byte) error {
-	return unpackV16AsV32(data, (*int32)(d), 10)
+	var i int16
+	if err := unpackV16(data, &i); err != nil {
+		return nil
+	}
+	*d = DPT_8003(int32(i) * 10)
+	return nil
 }
 
 func (d DPT_8003) Unit() string {
@@ -68,11 +74,16 @@ func (d DPT_8003) String() string {
 type DPT_8004 int32
 
 func (d DPT_8004) Pack() []byte {
-	return packV32AsV16(int32(d), 100)
+	return packV16(int16(int32(d) / 100))
 }
 
 func (d *DPT_8004) Unpack(data []byte) error {
-	return unpackV16AsV32(data, (*int32)(d), 100)
+	var i int16
+	if err := unpackV16(data, &i); err != nil {
+		return nil
+	}
+	*d = DPT_8004(int32(i) * 100)
+	return nil
 }
 
 func (d DPT_8004) Unit() string {
@@ -144,11 +155,16 @@ func (d DPT_8007) String() string {
 type DPT_8010 float32
 
 func (d DPT_8010) Pack() []byte {
-	return packFloat32AsV16(float32(d), 0.01)
+	return packV16(int16(math.Round(float64(d) / 0.01)))
 }
 
 func (d *DPT_8010) Unpack(data []byte) error {
-	return unpackV16AsFloat32(data, (*float32)(d), 0.01)
+	var i int16
+	if err := unpackV16(data, &i); err != nil {
+		return nil
+	}
+	*d = DPT_8010(float32(i) * 0.01)
+	return nil
 }
 
 func (d DPT_8010) Unit() string {

--- a/knx/dpt/types_8.go
+++ b/knx/dpt/types_8.go
@@ -1,0 +1,179 @@
+// Copyright 2017 Ole Krüger.
+// Licensed under the MIT license which can be found in the LICENSE file.
+
+package dpt
+
+import (
+	"fmt"
+)
+
+// DPT_8001 represents DPT 8.001 / Counter.
+type DPT_8001 int16
+
+func (d DPT_8001) Pack() []byte {
+	return packV16(int16(d))
+}
+
+func (d *DPT_8001) Unpack(data []byte) error {
+	return unpackV16(data, (*int16)(d))
+}
+
+func (d DPT_8001) Unit() string {
+	return "pulses"
+}
+
+func (d DPT_8001) String() string {
+	return fmt.Sprintf("%d pulses", int16(d))
+}
+
+// DPT_8002 represents DPT 8.002 / delta time ms.
+type DPT_8002 int16
+
+func (d DPT_8002) Pack() []byte {
+	return packV16(int16(d))
+}
+
+func (d *DPT_8002) Unpack(data []byte) error {
+	return unpackV16(data, (*int16)(d))
+}
+
+func (d DPT_8002) Unit() string {
+	return "ms"
+}
+
+func (d DPT_8002) String() string {
+	return fmt.Sprintf("%d ms", int16(d))
+}
+
+// DPT_8003 represents DPT 8.003 / delta time ms (range -327.68 s ... 327.67 s)
+type DPT_8003 int32
+
+func (d DPT_8003) Pack() []byte {
+	return packV32AsV16(int32(d), 10)
+}
+
+func (d *DPT_8003) Unpack(data []byte) error {
+	return unpackV16AsV32(data, (*int32)(d), 10)
+}
+
+func (d DPT_8003) Unit() string {
+	return "ms"
+}
+
+func (d DPT_8003) String() string {
+	return fmt.Sprintf("%d ms", int32(d))
+}
+
+// DPT_8004 represents DPT 8.004 / delta time ms (range -3276.8 s ... 3276.7 s)
+type DPT_8004 int32
+
+func (d DPT_8004) Pack() []byte {
+	return packV32AsV16(int32(d), 100)
+}
+
+func (d *DPT_8004) Unpack(data []byte) error {
+	return unpackV16AsV32(data, (*int32)(d), 100)
+}
+
+func (d DPT_8004) Unit() string {
+	return "ms"
+}
+
+func (d DPT_8004) String() string {
+	return fmt.Sprintf("%d ms", int32(d))
+}
+
+// DPT_8005 represents DPT 8.005 / delta time seconds
+type DPT_8005 int16
+
+func (d DPT_8005) Pack() []byte {
+	return packV16(int16(d))
+}
+
+func (d *DPT_8005) Unpack(data []byte) error {
+	return unpackV16(data, (*int16)(d))
+}
+
+func (d DPT_8005) Unit() string {
+	return "s"
+}
+
+func (d DPT_8005) String() string {
+	return fmt.Sprintf("%d s", int16(d))
+}
+
+// DPT_8006 represents DPT 8.005 / delta time minutes
+type DPT_8006 int16
+
+func (d DPT_8006) Pack() []byte {
+	return packV16(int16(d))
+}
+
+func (d *DPT_8006) Unpack(data []byte) error {
+	return unpackV16(data, (*int16)(d))
+}
+
+func (d DPT_8006) Unit() string {
+	return "min"
+}
+
+func (d DPT_8006) String() string {
+	return fmt.Sprintf("%d min", int16(d))
+}
+
+// DPT_8007 represents DPT 8.007 / delta time hours
+type DPT_8007 int16
+
+func (d DPT_8007) Pack() []byte {
+	return packV16(int16(d))
+}
+
+func (d *DPT_8007) Unpack(data []byte) error {
+	return unpackV16(data, (*int16)(d))
+}
+
+func (d DPT_8007) Unit() string {
+	return "h"
+}
+
+func (d DPT_8007) String() string {
+	return fmt.Sprintf("%d h", int16(d))
+}
+
+// DPT_8010 represents DPT 8.010 / percentage difference
+type DPT_8010 float32
+
+func (d DPT_8010) Pack() []byte {
+	return packFloat32AsV16(float32(d), 0.01)
+}
+
+func (d *DPT_8010) Unpack(data []byte) error {
+	return unpackV16AsFloat32(data, (*float32)(d), 0.01)
+}
+
+func (d DPT_8010) Unit() string {
+	return "%"
+}
+
+func (d DPT_8010) String() string {
+	return fmt.Sprintf("%f %%", float32(d))
+}
+
+// DPT_8011 represents DPT 8.011 / Rotation angle °.
+type DPT_8011 int16
+
+func (d DPT_8011) Pack() []byte {
+	return packV16(int16(d))
+}
+
+func (d *DPT_8011) Unpack(data []byte) error {
+	return unpackV16(data, (*int16)(d))
+}
+
+func (d DPT_8011) Unit() string {
+	return "°"
+}
+
+func (d DPT_8011) String() string {
+	return fmt.Sprintf("%d °", int16(d))
+}

--- a/knx/dpt/types_8_test.go
+++ b/knx/dpt/types_8_test.go
@@ -1,0 +1,207 @@
+// Copyright 2017 Ole Krüger.
+// Licensed under the MIT license which can be found in the LICENSE file.
+
+package dpt
+
+import (
+	"fmt"
+	"testing"
+
+	"math"
+	"math/rand"
+)
+
+// Test DPT 8.001 with values within range
+func TestDPT_8001(t *testing.T) {
+	var buf []byte
+	var src, dst DPT_8001
+
+	for i := 1; i <= 10; i++ {
+		value := int16(rand.Uint32() % math.MaxInt16)
+
+		// Pack and unpack to test value
+		src = DPT_8001(value)
+		if int16(src) != value {
+			t.Errorf("Assignment of value \"%v\" failed for source of type DPT_8001! Has value \"%s\".", value, src)
+		}
+		buf = src.Pack()
+		dst.Unpack(buf)
+		if int16(dst) != value {
+			t.Errorf("Value \"%s\" after pack/unpack different from Original value. Was \"%v\"", dst, value)
+		}
+	}
+}
+
+// Test DPT 8.002 with values within range
+func TestDPT_8002(t *testing.T) {
+	var buf []byte
+	var src, dst DPT_8002
+
+	for i := 1; i <= 10; i++ {
+		value := int16(rand.Uint32() % math.MaxInt16)
+
+		// Pack and unpack to test value
+		src = DPT_8002(value)
+		if int16(src) != value {
+			t.Errorf("Assignment of value \"%v\" failed for source of type DPT_8002! Has value \"%s\".", value, src)
+		}
+		buf = src.Pack()
+		dst.Unpack(buf)
+		if int16(dst) != value {
+			t.Errorf("Value \"%s\" after pack/unpack different from Original value. Was \"%v\"", dst, value)
+		}
+	}
+}
+
+// Test DPT 8.003 with values within range
+func TestDPT_8003(t *testing.T) {
+	var buf []byte
+	var src, dst DPT_8003
+
+	for i := 1; i <= 10; i++ {
+
+		value := int32(rand.Uint32()%math.MaxInt16) * 10
+
+		// Pack and unpack to test value
+		src = DPT_8003(value)
+		if int32(src) != value {
+			t.Errorf("Assignment of value \"%v\" failed for source of type DPT_8003! Has value \"%s\".", value, src)
+		}
+		buf = src.Pack()
+		dst.Unpack(buf)
+		if int32(dst) != value {
+			t.Errorf("Value \"%s\" after pack/unpack different from Original value. Was \"%v\"", dst, value)
+		}
+	}
+}
+
+// Test DPT 8.004 with values within range
+func TestDPT_8004(t *testing.T) {
+	var buf []byte
+	var src, dst DPT_8004
+
+	for i := 1; i <= 10; i++ {
+
+		value := int32(rand.Uint32()%math.MaxInt16) * 100
+
+		// Pack and unpack to test value
+		src = DPT_8004(value)
+		if int32(src) != value {
+			t.Errorf("Assignment of value \"%v\" failed for source of type DPT_8003! Has value \"%s\".", value, src)
+		}
+		buf = src.Pack()
+		dst.Unpack(buf)
+		if int32(dst) != value {
+			t.Errorf("Value \"%s\" after pack/unpack different from Original value. Was \"%v\"", dst, value)
+		}
+	}
+}
+
+// Test DPT 8.005 with values within range
+func TestDPT_8005(t *testing.T) {
+	var buf []byte
+	var src, dst DPT_8005
+
+	for i := 1; i <= 10; i++ {
+		value := int16(rand.Uint32() % math.MaxInt16)
+
+		// Pack and unpack to test value
+		src = DPT_8005(value)
+		if int16(src) != value {
+			t.Errorf("Assignment of value \"%v\" failed for source of type DPT_8005! Has value \"%s\".", value, src)
+		}
+		buf = src.Pack()
+		dst.Unpack(buf)
+		if int16(dst) != value {
+			t.Errorf("Value \"%s\" after pack/unpack different from Original value. Was \"%v\"", dst, value)
+		}
+	}
+}
+
+// Test DPT 8.006 with values within range
+func TestDPT_8006(t *testing.T) {
+	var buf []byte
+	var src, dst DPT_8006
+
+	for i := 1; i <= 10; i++ {
+		value := int16(rand.Uint32() % math.MaxInt16)
+
+		// Pack and unpack to test value
+		src = DPT_8006(value)
+		if int16(src) != value {
+			t.Errorf("Assignment of value \"%v\" failed for source of type DPT_8006! Has value \"%s\".", value, src)
+		}
+		buf = src.Pack()
+		dst.Unpack(buf)
+		if int16(dst) != value {
+			t.Errorf("Value \"%s\" after pack/unpack different from Original value. Was \"%v\"", dst, value)
+		}
+	}
+}
+
+// Test DPT 8.007 with values within range
+func TestDPT_8007(t *testing.T) {
+	var buf []byte
+	var src, dst DPT_8007
+
+	for i := 1; i <= 10; i++ {
+		value := int16(rand.Uint32() % math.MaxInt16)
+
+		// Pack and unpack to test value
+		src = DPT_8007(value)
+		if int16(src) != value {
+			t.Errorf("Assignment of value \"%v\" failed for source of type DPT_8007! Has value \"%s\".", value, src)
+		}
+		buf = src.Pack()
+		dst.Unpack(buf)
+		if int16(dst) != value {
+			t.Errorf("Value \"%s\" after pack/unpack different from Original value. Was \"%v\"", dst, value)
+		}
+	}
+}
+
+// Test DPT 8.010 with values within range
+func TestDPT_8010(t *testing.T) {
+	var buf []byte
+	var src, dst DPT_8010
+
+	for i := 1; i <= 10; i++ {
+
+		iValue := int16(rand.Uint32() % math.MaxInt16)
+		value := float32(iValue) / 100
+
+		src = DPT_8010(value)
+		if abs(float32(src)-value) > epsilon {
+			t.Errorf("Assignment of value \"%v\" failed for source of type DPT_8010! Has value \"%s\".", value, src)
+		}
+		buf = src.Pack()
+		_ = dst.Unpack(buf)
+		if math.IsNaN(float64(dst)) {
+			t.Errorf("Value \"%s\" is not a valid number! Original value was \"%v\".", dst, value)
+		}
+		if fmt.Sprintf("%.2f", dst) != fmt.Sprintf("%.2f", value) {
+			t.Errorf("Value \"%f\" after pack/unpack different from Original value. Was \"%f\"", dst, value)
+		}
+	}
+}
+
+// Test DPT 8.011 (°) with values within range
+func TestDPT_8011(t *testing.T) {
+	var buf []byte
+	var src, dst DPT_8011
+
+	for i := 1; i <= 10; i++ {
+		value := int16(rand.Uint32() % math.MaxInt16)
+
+		// Pack and unpack to test value
+		src = DPT_8011(value)
+		if int16(src) != value {
+			t.Errorf("Assignment of value \"%v\" failed for source of type DPT_8011! Has value \"%s\".", value, src)
+		}
+		buf = src.Pack()
+		dst.Unpack(buf)
+		if int16(dst) != value {
+			t.Errorf("Value \"%s\" after pack/unpack different from Original value. Was \"%v\"", dst, value)
+		}
+	}
+}

--- a/knx/dpt/types_registry.go
+++ b/knx/dpt/types_registry.go
@@ -58,6 +58,17 @@ var dptTypes = map[string]Datapoint{
 	"7.013": new(DPT_7013),
 	"7.600": new(DPT_7600),
 
+	// 8.xxx
+	"8.001": new(DPT_8001),
+	"8.002": new(DPT_8002),
+	"8.003": new(DPT_8003),
+	"8.004": new(DPT_8004),
+	"8.005": new(DPT_8005),
+	"8.006": new(DPT_8006),
+	"8.007": new(DPT_8007),
+	"8.010": new(DPT_8010),
+	"8.011": new(DPT_8011),
+
 	// 9.xxx
 	"9.001": new(DPT_9001),
 	"9.002": new(DPT_9002),


### PR DESCRIPTION
Creating a new PR (previous #91) to keep the conversation clean since I've done some research now.

There were some confusion on how to represent fields with a different resolution than 1 which is the case for 8.003, 8.004 and 8.010. My conclusion is that the unit presented in the KNX specification is indeed what ETS uses to present the values when listening on the bus.

This means that:
* 8.003 and 8.004 are both presented as `ms` as value of int16 times their respective resolution.
* 8.010 is presented in `%` as value of int16 times its resolution.

If we want to stay accurate with ETS this means 8.003 and 8.004 needs to be stored in int32 and 8.010 in float32.

I did some test writes from ETS5. For 8.003 and 8.004 I was sending raw value of `5891`. For 8.010 I was sending raw value of `98.56`. This is what ETS showed:
![image](https://github.com/user-attachments/assets/57f61332-3169-486e-a9a4-c45c9481e8da)

And this is what my application showed (using this version of knx-go):
![image](https://github.com/user-attachments/assets/b6a44bee-3cb0-45d1-b866-7d13c0620fcf)

Note how 8.003 truncates 1 digit (due to resolution of 10) and 8.004 truncates 2 digits (due to resolution of 100). This is the same behaviour in this branch.

ETS seemingly present 8.010 after first converting it to a floating point number, so even if I write `98.56` it prints as `98.5599977970123 %`. Similarly, this PR does the same but due to a difference in precision it's slightly different. However, when rounding to its resolution (in this case 2 digits) they will always be the same.