### PR TITLE
Fix golangci error

### DIFF
--- a/knx/knxnet/errcodes.go
+++ b/knx/knxnet/errcodes.go
@@ -89,7 +89,7 @@ func (err ErrCode) String() string {
 		return "Unsupported tunnelling layer"
 
 	default:
-		return fmt.Sprintf("Unknown error code %#x", err)
+		return fmt.Sprintf("Unknown error code %#x", uint8(err))
 	}
 }
 


### PR DESCRIPTION
This fixes the issue of golangci recognizing potential recursion in fmt.Sprintf (see [Issue #73825](https://github.com/golang/go/issues/73825)) by converting the value of type `ErrCode `back to `uint8`.